### PR TITLE
Updates the term ID in the metadata instead of skipping if it already exists.

### DIFF
--- a/src/connection-types/taxonomy/taxonomy.php
+++ b/src/connection-types/taxonomy/taxonomy.php
@@ -227,10 +227,7 @@ class O2O_Connection_Taxonomy extends aO2O_Connection implements iO2O_Connection
 		// add_post_meta( $object_id, 'o2o_term_id', $term_id, true );
 		// modified by Chris Wilson, 6/29/15
 		// perhaps due to imported content, we have a bunch of mismatched term-ids. This fixes it.
-
-		if (!add_post_meta( $object_id, 'o2o_term_id', $term_id, true)) {
-			update_post_meta ( $object_id, 'o2o_term_id', $term_id );
-		}
+		update_post_meta ( $object_id, 'o2o_term_id', $term_id );
 
 		wp_cache_set( 'o2o_object_' . $term_id, $object_id );
 

--- a/src/connection-types/taxonomy/taxonomy.php
+++ b/src/connection-types/taxonomy/taxonomy.php
@@ -224,7 +224,14 @@ class O2O_Connection_Taxonomy extends aO2O_Connection implements iO2O_Connection
 
 		wp_cache_set( 'o2o_term_exists_' . $this->taxonomy . '_' . $term_id, true );
 
-		add_post_meta( $object_id, 'o2o_term_id_' . $this->taxonomy, $term_id, true );
+		// add_post_meta( $object_id, 'o2o_term_id', $term_id, true );
+		// modified by Chris Wilson, 6/29/15
+		// perhaps due to imported content, we have a bunch of mismatched term-ids. This fixes it.
+
+		if (!add_post_meta( $object_id, 'o2o_term_id', $term_id, true)) {
+			update_post_meta ( $object_id, 'o2o_term_id', $term_id );
+		}
+
 		wp_cache_set( 'o2o_object_' . $term_id, $object_id );
 
 		return $term_id;


### PR DESCRIPTION
I imported a bunch of content from a dev instance of my WP site to the production instance. Much of it is interconnected using o2o.

But the term_ids got all messed up in the process, and now the site breaks every time the cache is cleared. Basically, any time I created a new connection, it would be successfully registered with the `wp_cache_set` call, but the correct term ID would not be written to the content's meta data since `add_post_meta` was set to be unique.

An alternative fix, perhaps safer, would be to set the unique flag to false on `add_post_meta` on line 227. 

Allowing o2o to update the value of the term_id fixes the problem for me.