### PR TITLE
Explicitly load Composer's autoloader

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -1,29 +1,33 @@
 <?php
 
-if ( !class_exists( 'Composer\Autoload\ClassLoader' ) ) {
-	//loadd classes if library not managed by composer
-	if ( !class_exists( 'O2O' ) ) {
+// Use Composer's autoloader if it exists
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once( __DIR__ . '/vendor/autoload.php' );
+}
+// Otherwise, load classes manually
+else {
+	if ( ! class_exists( 'O2O' ) ) {
 		require_once ( __DIR__ . '/src/o2o.php' );
 	}
 
-	if ( !class_exists( 'O2O_Connection_Factory' ) ) {
+	if ( ! class_exists( 'O2O_Connection_Factory' ) ) {
 		require_once ( __DIR__ . '/src/factory.php' );
 	}
 
-	if ( !class_exists( 'O2O_Query' ) ) {
+	if ( ! class_exists( 'O2O_Query' ) ) {
 		require_once ( __DIR__ . '/src/query.php' );
 	}
 
-	if ( !class_exists( 'O2O_Rewrites' ) ) {
+	if ( ! class_exists( 'O2O_Rewrites' ) ) {
 		require_once ( __DIR__ . '/src/rewrites.php' );
 	}
 
-	if ( !class_exists( 'O2O_Connection_Taxonomy' ) ) {
+	if ( ! class_exists( 'O2O_Connection_Taxonomy' ) ) {
 		require_once ( __DIR__ . '/src/connection-types/taxonomy/taxonomy.php' );
 	}
 }
 
 $o2oInstance = O2O::GetInstance();
-if ( !has_action( 'init', array( $o2oInstance, 'init' ) ) ) {
+if ( ! has_action( 'init', array( $o2oInstance, 'init' ) ) ) {
 	add_action( 'init', array( O2O::GetInstance(), 'init' ), 20 );
 }


### PR DESCRIPTION
This change checks if the Composer autoloader is present, and uses that as first preference. Only if it doesn't do the classes get manually loaded.

Otherwise, folks using the plugin have to explicitly include the autoloader somewhere else, such as in their theme which is probably more effort than should be necessary.